### PR TITLE
Change description, make shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,31 +57,7 @@ Using Python 3.10 and Windows 10 OS
 + `<gml:id>` for each `<bldg:Building>` and other types of city objects
 + `<gml:id>` for each `<gml:Polygon>`
 
-## How to run?
-In order to run the converter, the following run/debug configurations are required:
-<br></br>
-
-
-  `-i  your-input-path-here` 
-  
-  `-o  your-output-path-here` 
-  
-
-Additional configurations have to be made in order to make use of the different optional features:
-<br></br>
-
-| Optional feature | specification | short explanation |
-| -------- | -------- | -------- |
-| Semanitcs Option|`-s 1`| create an individual OBJ file for each of the boundary surfaces |
-| Geometry Validation | `-v 1`| validate the geometries and skip invalid ones |
-| Object Preservation | `-g 1`| keep the names of the objects |
-| Skip the triangulation | `-p 1`| preserve polygons in the OBJ file |
-| Conversion of the resulting dataset into a local coordinate system | `-t 1`| convert the resulting dataset to a local system |
-| Translation of the CityGML dataset into a local coordinate system pefore further processing, without / with saving the translation parameters|`-tC 1` `-tCw 1`| translate the CityGML dataset into a local CRS before processing | 
-
-More detailed information on the optional features can be found in this [Wiki Page](https://github.com/tum-gis/citygml2obj-2.0/wiki/Optional-Functionalities)
-
-
+ 
 ## Limitations
 
 Information on the limitations can be found in this [Wiki Page](https://github.com/tum-gis/citygml2obj-2.0/wiki/Limitations) 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,28 @@
-# CityGML2OBJ 2.0
-Command line converter of CityGML (.gml) to OBJ (.obj) files, while maintaining the semantics 
+# :cityscape: CityGML2OBJ 2.0 :cityscape:
+Command line converter of **CityGML (.gml)** to **OBJ (.obj)** files, while maintaining the semantics 
 
 ![Unbenanntes Diagramm drawio(7)](https://user-images.githubusercontent.com/44395224/233409267-88acb0b3-b8b2-40e5-9b9d-5fa763229956.png)
+
+## :arrow_forward: How to run?
+Open your command line and type in:
+  
+  `-i  your-input-citygml-path-here` 
+  
+  `-o  your-output-obj-path-here` 
+
+and Bob's your uncle! :construction_worker:
+
+### :wrench: Optional features
+
+| Optional feature | specification |
+| -------- | -------- |
+| Semanitcs Option|`-s 1`|
+| Geometry Validation | `-v 1`|
+| Object Preservation | `-g 1`|
+| Skip the triangulation | `-p 1`|
+| Conversion of the resulting dataset into a local coordinate system | `-t 1`|
+| Translation of the CityGML dataset into a local coordinate system before further processing, without saving the translation parameters|`-tC 1`|
+| Translation of the CityGML dataset into a local coordinate system before further processing, with saving the translation parameters to a designated .txt file|`-tCw 1`|
 
 
 ## Features
@@ -16,9 +37,8 @@ This conversion tool provides several additional optional functionalities:
 | Conversion of the resulting dataset into a local coordinate system | Normally CityGML data sets are geo-referenced. This may be a problem for some software packages. This option can be used in order to convert the data set to a local system. The origin of the local system correspond to the point with the smallest coordinates (usually the one closest to south-west). this conversion takes place after theprocessing and only affects the vertices in the OBJ file. |
 | Translation of the CityGML dataset into a local coordinate system pefore further processing |Invoke this option in order to translate the CityGML File into a local coordinate system before performing the conversion to OBJ. The translated dataset is saved as a new GML file in the output directory as well. Optionally, the translation parameters can be saved into a designated .txt file called `NameOfTheCityGMLDataset_Translation_Parameters.txt`. The translation parameters are determined from the envelopes specified in the GML document. Therefore, the translation only takes place in the horizontal directions, a height translation is not applied automatically. It is possible to apply a height translation manually by inserting the height correction in the `CityGML2OBJs` file in line 420 or 424. This functionality is also able to perform the translation of objets that are defined using implicite geometry (e.g vegetation objects)|
 
-Without any of these options invoked, a simple straightforward conversion from CityGML to OBJ will be performed.
 
-## Requirements
+## :page_with_curl: Requirements
 ### Python packages:
 
 + [Numpy](http://docs.scipy.org/doc/numpy/user/install.html) 
@@ -27,13 +47,13 @@ Without any of these options invoked, a simple straightforward conversion from C
 + [Shapely](https://github.com/Toblerity/Shapely)
 + [Decimal](https://docs.python.org/3/library/decimal.html)
   
-Optional:
+#### Optional:
 
 + [Matplotlib](http://matplotlib.org/users/installing.html)
 
-### Operating System:
+### Tested:
 
-The original project code has been developed on Mac OSX in Python 2.7. It has been adapted to python 3.10 and was successfully tested on a Windows 10 OS.
+Using Python 3.10 and Windows 10 OS
 
 ### CityGML Requirements:
 
@@ -42,44 +62,13 @@ The original project code has been developed on Mac OSX in Python 2.7. It has be
 + CityGML 1.0 or 2.0
 + Files must end with `.gml`, `.GML`, `.xml`, or `.XML`
 + Vertices in either `<gml:posList>` or `<gml:pos>`
-+ Your files must be valid (see the next section)
-
-<span style="color:red">The conversion tool does not work for CityGML 3.0 !</span>*
-
-You can check your CityGML files for validity for example with the [CityDoctor](https://www.citydoctor.eu/de/startseite.html) software.
++ Your files must be valid (e.g., free check with [CityDoctor](https://www.citydoctor.eu/de/startseite.html))
 
 #### Optional, but recommended:
 
 + `<gml:id>` for each `<bldg:Building>` and other types of city objects
 + `<gml:id>` for each `<gml:Polygon>`
 
-## How to run?
-In order to run the converter, the following run/debug configurations are required to run the program code:
-<br></br>
-
-
-
-  
-  `-i  your-input-path-here` 
-  
-  `-o  your-output-path-here` 
-  
-
-  
-
-<br></br>
-Additional configurations have to be made in order to make use of the different optional features:
-<br></br>
-
-| Optional feature | specification |
-| -------- | -------- |
-| Semanitcs Option|`-s 1`|
-| Geometry Validation | `-v 1`|
-| Object Preservation | `-g 1`|
-| Skip the triangulation | `-p 1`|
-| Conversion of the resulting dataset into a local coordinate system | `-t 1`|
-| Translation of the CityGML dataset into a local coordinate system pefore further processing, without saving the translation parameters|`-tC 1`|
-| Translation of the CityGML dataset into a local coordinate system pefore further processing, with saving the translation parameters to a designated .txt file|`-tCw 1`|
 
 ## Known Limitations
 
@@ -102,5 +91,17 @@ Additional configurations have to be made in order to make use of the different 
 </div>
 
 
-## Credits
-We are indebted to [Filip Biljecki](https://github.com/fbiljecki), [Hugo Ledoux](https://github.com/hugoledoux) and [Ravi Peters](https://github.com/Ylannl) from [TU Delft](https://github.com/tudelft3d) for their initial version of the CityGML2OBJs converter. The archived version of the repo can still be found here: https://github.com/tudelft3d/CityGML2OBJs
+## :handshake: Credits
+We are indebted to [Filip Biljecki](https://github.com/fbiljecki), [Hugo Ledoux](https://github.com/hugoledoux) and [Ravi Peters](https://github.com/Ylannl) from [TU Delft](https://github.com/tudelft3d) for their initial version of the CityGML2OBJs converter. The archived version of the repo can still be found here: https://github.com/tudelft3d/CityGML2OBJs; the paper: 
+
+Biljecki, F., & Arroyo Ohori, K. (2015). Automatic semantic-preserving conversion between OBJ and CityGML. Eurographics Workshop on Urban Data Modelling and Visualisation 2015, pp. 25-30.
+
+[[PDF]](http://filipbiljecki.com/publications/Biljecki2015vk.pdf) [[DOI]](http://doi.org/10.2312/udmv.20151345)
+
+## :mailbox: Contact & Feedback
+
+Feel free to open a discussion under Issues or write us an email
+
+- [Thomas Froech](thomas.froech@tum.de)
+- [Benedikt Schwab](benedikt.schwab@tum.de) 
+- [Olaf Wysocki](olaf.wysocki@tum.de)


### PR DESCRIPTION
Proposed changes:
-Besides the already changed parts, can we move the detaield description to the Wiki? It's a bit overloading the Readme file. Instead, I'd add another column to the "Optional feature" table called "Short description" and Wiki-link longer descriptions. Basically, this means that the chapter 'Features' should be moved to the Wiki 

-Actually, I'd move the 'Known limitations' to the Wiki, too. It's quite a list, which again overloads a potential reader. But I'll link it from this page. -All the "to-do" we can directly open as an issue under the Issue tab and link it from the Readme / Wiki. 

-Regarding the main photo: Can we make a screenshot from the exactly same perspective?